### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2](https://github.com/Miaxos/wasmio/compare/wasmio-aws-types-v0.0.1...wasmio-aws-types-v0.0.2) - 2024-02-12
+
+### Added
+- add simple get implementation
+- add impl for list v2
+- add a proper way to implement different drivers with different errors
+- remove methods and put handlers
+- handler way to handle routes
+
+### Other
+- clippy
+- trying to fix the deploy
+
 ## [0.0.10](https://github.com/Miaxos/wasmio/compare/wasmio-v0.0.9...wasmio-v0.0.10) - 2024-02-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -969,9 +969,9 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1844,18 +1844,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2284,7 +2284,7 @@ checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasmio"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "wasmio-aws-types"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "axum",
  "derivative",

--- a/app/wasmio/Cargo.toml
+++ b/app/wasmio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmio"
-version = "0.0.10"
+version = "0.0.11"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/lib/wasmio-aws-types/Cargo.toml
+++ b/lib/wasmio-aws-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmio-aws-types"
-version = "0.0.1"
+version = "0.0.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `wasmio`: 0.0.10 -> 0.0.11 (✓ API compatible changes)
* `wasmio-aws-types`: 0.0.1 -> 0.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `wasmio`
<blockquote>

## [0.0.11](https://github.com/Miaxos/wasmio/compare/wasmio-v0.0.10...wasmio-v0.0.11) - 2024-02-12

### Added
- add simple get implementation
- add impl for list v2
- some new errors
- add a proper way to implement different drivers with different errors
- remove methods and put handlers
- add some tests
- add path to context
- handler way to handle routes
- revamp the routing behavior

### Fixed
- ressource to resource

### Other
- clippy
- clippy
- simple e2e tests
- trying to fix the deploy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).